### PR TITLE
add a `reset()` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 7.1.0
+### 8.2.0
 
 - Added a `reset()` method that can be used to reset the entire `server.app.config` object
 - Formalized the `get()` behavior where calling `get()` with no key returns the entire config object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.1.0
+
+- Added a `reset()` method that can be used to reset the entire `server.app.config` object
+- Formalized the `get()` behavior where calling `get()` with no key returns the entire config object
 
 ### 8.1.1
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ const init = async function (options) {
 
         register: function (server) {
 
-            const appSettings = store.get('server.app') || {};
+            let appSettings = store.get('server.app') || {};
 
             Object.defineProperty(server.app, 'config', {
                 enumerable: false,
@@ -66,11 +66,19 @@ const init = async function (options) {
                 value: {
                     get(key) {
 
+                        if (!key) {
+                            return appSettings;
+                        }
+
                         return Props.get(appSettings, key);
                     },
                     set(key, value) {
 
                         Props.set(appSettings, key, value);
+                    },
+                    reset(config) {
+
+                        appSettings = config;
                     }
                 }
             });

--- a/test/test-steerage.js
+++ b/test/test-steerage.js
@@ -5,7 +5,7 @@ const Steerage = require('../lib');
 const Path = require('path');
 
 Test('configures', async function (t) {
-    t.plan(7);
+    t.plan(10);
 
     try {
         const server = await Steerage.init({ config: Path.join(__dirname, 'fixtures', 'config', 'config.json') });
@@ -24,9 +24,16 @@ Test('configures', async function (t) {
 
         t.equal(server.app.config.get('name'), 'testApp', 'server.app.config get.');
 
+        t.deepEqual(server.app.config.get(), { nested: {}, name: 'testApp', nameCopy: 'testApp' }, 'server.app.config.get entire config.');
+
         server.app.config.set('hello.world', 'hello world!');
 
         t.equal(server.app.config.get('hello.world'), 'hello world!', 'server.app.config set.');
+
+        server.app.config.reset({ foo: 'bar' });
+
+        t.equal(server.app.config.get('foo'), 'bar', 'server.app.config reset.');
+        t.equal(server.app.config.get('hello.world'), undefined, 'server.app.config reset.');
     }
     catch (error) {
         console.log(error.stack);


### PR DESCRIPTION
We're building a runtime configuration plugin for Hapi+Catalyst apps that needs the ability to completely reset the `server.app.config` object.  This PR adds support for that capability via a new `reset()` API exposed on the `server.app.config` object.

This PR also formalizes the behavior where calling `server.app.config.get()` returns the entire config object.  This behavior was already exposed by `dot-prop`:

https://github.com/sindresorhus/dot-prop/blob/master/index.js#L36-L38

But has now been hoisted into the Steerage plugin to ensure that future releases of `dot-prop` don't break this behavior.