### PR TITLE
Use `@vrbo` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Supports environment-aware configuration and more using [determination](https://
 
 ### Usage
 
-**Please note:** steerage version 8.x now requires hapi v18 - if you are still on hapi v17, please continue to use steerage version 7.x instead.
+**Please note:**
+* steerage version 8.x now requires hapi v18 - if you are still on hapi v17, please continue to use steerage version 7.x instead.
+* Versions >=7 are now available as `@vrbo/steerage`. Releases are no longer published as `steerage`.
 
 ```javascript
 const Path = require('path');
-const Steerage = require('steerage');
+const Steerage = require('@vrbo/steerage');
 
 Steerage.init({ config: Path.join(__dirname, 'config', 'config.json') }).then((server) => {
     server.start();
@@ -35,7 +37,7 @@ Steerage.init({ config: Path.join(__dirname, 'config', 'config.json') }).then((s
 
 ```javascript
 const Path = require('path');
-const Steerage = require('steerage');
+const Steerage = require('@vrbo/steerage');
 const Determination = require('determination');
 
 const overrideResolve = Determination.create({ config: Path.join(__dirname, 'config', 'overrides.json') });

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "steerage",
+  "name": "@vrbo/steerage",
   "description": "Hapi plugin for server configuration and composition using confidence, topo, and shortstop.",
   "version": "8.1.1",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/tlivings/steerage.git"
+    "url": "git://github.com/expediagroup/steerage.git"
   },
-  "bugs": "http://github.com/tlivings/steerage/issues",
+  "bugs": "http://github.com/expediagroup/steerage/issues",
   "engines": {
     "node": ">= 8.0.0"
   },


### PR DESCRIPTION
Changing the the module name to `@vrbo/steerage`. This will allow us to publish the module in NPM under the `@vrbo` org.