### PR TITLE
chore(build process): Add semantic-release workflow [skip ci]

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,8 +3,15 @@ name: Node_CI
 on: [pull_request,push]
 
 jobs:
-  build:
+  prepare: # Do not run workflow for chore commits https://bit.ly/39qUH60
+    runs-on: ubuntu-latest
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - run: echo "${{ github.event.head_commit.message }}"
 
+  build:
+    needs: prepare
+    name: Build
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  prepare: # Do not run workflow for chore commits https://bit.ly/39qUH60
+    runs-on: ubuntu-latest
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - run: echo "${{ github.event.head_commit.message }}"
+
+  release:
+    needs: prepare
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: npm install
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    ["@semantic-release/git", {
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "node": ">= 12.0.0",
     "npm": ">=6.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
     "@hapi/topo": "^3.0.0",
@@ -27,6 +30,8 @@
     "@hapi/eslint-config-hapi": "^12.1.0",
     "@hapi/eslint-plugin-hapi": "^4.3.3",
     "@hapi/hapi": "^19.2.0",
+    "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/git": "^9.0.0",
     "eslint": "^5.15.1",
     "nyc": "^14.1.1",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
Adding semantic release workflow similar to this [PR to `pino-rotating-file`](https://github.com/ExpediaGroup/pino-rotating-file/pull/20).

[Added a `publishConfig` field to `package.json`](https://github.com/semantic-release/semantic-release/issues/512#issuecomment-363976638) in hopes of solving the [issue seen that prevented the `semantic-release` plugin from successfully publishing](https://github.com/ExpediaGroup/pino-rotating-file/runs/919835203?check_suite_focus=true) `pino-rotating-file` to npm.

Once this is merged we can test out a fix (patch) release by [merging this dependabot PR.](https://github.com/ExpediaGroup/steerage/pull/26)