### PR TITLE
feat: upgrade @vrbo/determination to V6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
     "@hapi/topo": "^5.0.0",
-    "@vrbo/determination": "^4.0.0",
+    "@vrbo/determination": "^6.0.0",
     "dot-prop": "^5.2.0",
     "joi": "^17.2.0",
     "shortstop-handlers": "^1.0.1"


### PR DESCRIPTION
BREAKING CHANGE: This updates @vrbo/determination from the range `^4.0.0` to
`^6.0.0`. Please validate your dependencies on this can use this version and update as needed.