### PR TITLE
feat: exposes overrides and defaults from determination

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Steerage.init({ config: Path.join(__dirname, 'config', 'config.json') }).then((s
 - `onconfig(store)` - Hook for modifying config prior to creating list of plugins to register — may be async function or promise.
 - `protocols` - (Optional) Additional custom [shortstop](https://github.com/krakenjs/shortstop) protocols.
 - `environment` - (Optional) Additional criteria for [confidence](https://github.com/hapijs/confidence) property resolution and defaults to `{ env: process.env }`.
+- `defaults` (_Object_ | _String_) - optional default pre-resolved configuration values.
+- `overrides` (_Object_ | _String_) - optional override pre-resolved configuration values.
 
 ### Example onconfig hook
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,7 @@ const Handlers = require('shortstop-handlers');
 const Hoek = require('@hapi/hoek');
 const Determination = require('@vrbo/determination');
 
-const resolve = async function ({ config, basedir, protocols, environment }) {
+const resolve = async function ({ config, basedir, protocols, environment, defaults, overrides }) {
 
     const defaultProtocols = {
         file: Handlers.file(basedir),
@@ -47,6 +47,8 @@ const resolve = async function ({ config, basedir, protocols, environment }) {
     const resolver = Determination.create({
         config,
         protocols,
+        defaults,
+        overrides,
         criteria: environment
     });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,9 @@ const schema = Joi.object({
     config: Joi.array().items(Joi.string()).single().required(),
     environment: Joi.object().default({ env: process.env }),
     onconfig: Joi.function().allow(null),
-    protocols: Joi.object().default()
+    protocols: Joi.object().default(),
+    defaults: Joi.alternatives(Joi.string(), Joi.object()).default({}),
+    overrides: Joi.alternatives(Joi.string(), Joi.object()).default({})
 }).required();
 
 const init = async function (options) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,9 @@ const Utils = {
             basedir,
             config,
             environment,
-            protocols
+            protocols,
+            defaults,
+            overrides
         } = options;
 
         let resolved;
@@ -42,7 +44,9 @@ const Utils = {
                 config: configPath,
                 basedir: basedir || Path.dirname(configPath),
                 protocols,
-                environment
+                environment,
+                defaults,
+                overrides
             });
 
             if (!resolved) {

--- a/test/test-steerage.js
+++ b/test/test-steerage.js
@@ -120,6 +120,37 @@ Test('multiple config paths', async (t) => {
     }
 });
 
+Test('determination properties for defaults and overrides', async (t) => {
+
+    try {
+        const server = await Steerage.init({
+            config: Path.join(__dirname, 'fixtures', 'config', 'config.json'),
+            defaults: {
+                server: {
+                    app: {
+                        foo: 'bar'
+                    }
+                }
+            },
+            overrides: {
+                server: {
+                    app: {
+                        name: 'overriddenName'
+                    }
+                }
+            }
+        });
+
+        t.equal(server.app.config.get('foo'), 'bar', 'adds default property.');
+        t.equal(server.app.config.get('name'), 'overriddenName', 'overrides a property.');
+
+        t.end();
+    }
+    catch (error) {
+        console.log(error.stack);
+    }
+});
+
 Test('disable plugin', async (t) => {
 
     try {


### PR DESCRIPTION
Determination has two additional properties that were not exposed by Steerage. This PR exposes them. These properties allow us to pass in **_objects_** as config, prior to the determination resolution. 