### PR TITLE
Test npm publish without  semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,19 +12,15 @@ jobs:
 
   release:
     needs: prepare
-    name: Release
+    name: publish
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 14
-      - name: Install dependencies
-        run: npm install
-      - name: Release
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
steerage is now using semantic-release, and we do not know if it is some configuration error or because npm-token is expired.

this PR avoids the use of semantic-release, if we can publish steerage to NPM registry with this PR,  then we know if the problem is  semantic-release specific