### PR TITLE
fix: explicitly force determination 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
     "@hapi/topo": "^5.0.0",
-    "@vrbo/determination": "^6.0.0",
+    "@vrbo/determination": "^6.0.1",
     "dot-prop": "^5.2.0",
     "joi": "^17.2.0",
     "shortstop-handlers": "^1.0.1"


### PR DESCRIPTION
Forcing 6.0.1 of determination so package-locks are updated on consuming applications.