### PR TITLE
chore: use semantic-release's default assets so that package.json is …

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,6 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md"],
         "message": "${nextRelease.version} CHANGELOG [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrbo/steerage",
-  "version": "12.1.1",
+  "version": "12.1.3",
   "description": "Hapi plugin for server configuration and composition using confidence, topo, and shortstop.",
   "bugs": "http://github.com/expediagroup/steerage/issues",
   "repository": {


### PR DESCRIPTION
The package.json was not being committed back to the repo with the release commit that semantic-release performs. It was because we were overriding the assets array. The defaults should instead be used which includes package.json and CHANGELOG.md