### PR TITLE
feat: Add a functionality to load things before/outside the server 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,10 @@
 
 'use strict';
 
+const { catalystTracer } = require('./utils');
+
+catalystTracer();
+
 const Pkg = require('../package.json');
 const Plugins = require('./plugins');
 const Joi = require('joi');

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@
 
 const { catalystTracer } = require('./utils');
 
-catalystTracer();
+const tracer = (config) => catalystTracer();
 
 const Pkg = require('../package.json');
 const Plugins = require('./plugins');
@@ -108,4 +108,4 @@ const init = async function (options) {
     return server;
 };
 
-module.exports = { init };
+module.exports = { tracer, init };

--- a/lib/init-config.jsonc
+++ b/lib/init-config.jsonc
@@ -1,0 +1,34 @@
+{
+    // don't change this value here...
+    "initLibraries": {
+        "hapiDatadogInstrumentation": {
+            // datadog tracer options: https://github.com/DataDog/dd-trace-js/blob/e34b68b966cf807f3cbff768848155b6649412fb/index.d.ts#L188
+            "tracerOptions": {
+                "logInjection": true
+            },
+            // https://datadoghq.dev/dd-trace-js/modules/plugins.html
+            "pluginOptions": [
+                {
+                    // see config options https://datadoghq.dev/dd-trace-js/interfaces/plugins.hapi.html
+                    "name": "hapi",
+                    "config": {
+                        "blocklist": [
+                            "/management/health"
+                        ]
+                    }
+                }
+            ]
+        },
+        // add more packages here if needed
+        "otherPackage": {
+            "options": {
+                // shortstop-handlers are available at this file ex:
+                "option1": {
+                    "$filter": "env.NODE_ENV",
+                    "production": "productionvalue",
+                    "$default": "defaultvalue"
+                }
+            }
+        }
+    }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,13 @@
 'use strict';
 
+const { GetTracerConfig } = require('hapi-datadog-intrumentation/lib');
 const Path = require('path');
 const Config = require('./config');
 
 const Utils = {
+    catalystTracer() {
+        GetTracerConfig(Path.join(__dirname, 'init-config.jsonc'));
+    },
     async createConfigResolver(options) {
         // Some file watchers only watch a file if it's been require'd.
         // Determination doesn't call "require()" on the file internally,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
     "@hapi/topo": "^5.0.0",
-    "@vrbo/determination": "^6.0.1",
+    "@vrbo/determination": "^6.1.0",
     "dot-prop": "^5.2.0",
     "joi": "^17.2.0",
     "shortstop-handlers": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@hapi/topo": "^5.0.0",
     "@vrbo/determination": "^6.1.0",
     "dot-prop": "^5.2.0",
+    "hapi-datadog-intrumentation": "^1.0.15",
     "joi": "^17.2.0",
     "shortstop-handlers": "^1.0.1"
   },


### PR DESCRIPTION
# Adds the ability to process javascript objects.
- Explicitly force [determination 6.1.0](https://github.com/ExpediaGroup/determination/blob/master/CHANGELOG.md#610-2022-02-09)
So the steerage will process/allow objects for the configuration when pass the options to create a determination.

[**Before this pr:**](https://github.com/ExpediaGroup/steerage/blob/07b1f0b32d71bbcdf1ae586d764d5c3f87ad3f7a/lib/config.js#L47)
```
    const resolver = Determination.create({
        config, // alow only string path
        protocols,
        defaults,
        overrides,
        criteria: environment
    });

    return await resolver.resolve();
};
```

Now we can pass a object:

```
    const resolver = Determination.create({
        config, // allow path or object
        protocols,
        defaults,
        overrides,
        criteria: environment
    });

    return await resolver.resolve();
};
```
