### PR TITLE
feat: empty commit to trigger release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## [12.1.3](https://github.com/expediagroup/steerage/compare/v12.1.2...v12.1.3) (2022-01-11)
 
-
 ### Bug Fixes
 
 * explicitly force determination 6.0.1 ([#39](https://github.com/expediagroup/steerage/issues/39)) ([5c6268b](https://github.com/expediagroup/steerage/commit/5c6268b57f3dee72ff9e43063ed0b18a43dd8e24))


### PR DESCRIPTION
The prior change set used the wrong release token and failed to produce a release; this corrects that.