### PR TITLE
fix: Altering the order of semantic release config file to have it correct

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,13 +4,13 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
+    "@semantic-release/npm",
     [
       "@semantic-release/git",
       {
         "message": "${nextRelease.version} CHANGELOG [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/npm",
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
[CAT-1548](https://jira.expedia.biz/browse/CAT-1548)

Modifying order of the imports for the semantic release to add correctly the version on the package, this fix where commented here:

https://github.com/semantic-release/semantic-release/issues/1593#issuecomment-656866839

Tested changes on my fork repo:
https://github.com/YosafatEG/steerage

package.json and package-lock.json were correctly edited:

![image](https://user-images.githubusercontent.com/85510549/218827660-4e830ee3-c96a-4f39-a675-90834735295b.png)

![image](https://user-images.githubusercontent.com/85510549/218827698-aad8c3ec-41de-4941-8edb-60be10d1f3d8.png)

![image](https://user-images.githubusercontent.com/85510549/218827733-08c23730-971f-489e-b5e9-59727a0ce12b.png)

![image](https://user-images.githubusercontent.com/85510549/218827753-3c54c643-b2a6-413d-9224-205b3e65d4e0.png)

PR: https://github.com/YosafatEG/steerage/commit/b64e2aece6694efdf93deef9d2b53c5968fdc7f5